### PR TITLE
Make cable_ready a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "prettier-standard:check": "yarn run prettier-standard --check *.js **/*.js",
     "prettier-standard:format": "yarn run prettier-standard *.js **/*.js"
   },
-  "dependencies": {
-    "cable_ready": "5.0.0-pre0"
+  "peerDependencies": {
+    "cable_ready": ">= 5.0.0-pre0 <6"
   },
   "devDependencies": {
     "prettier-standard": "^16.4.1"


### PR DESCRIPTION
This is essentially a plugin that expects cable_ready to already be present. 
By making it a peerDependency, it will not install a second copy in the user's node_modules folder, and instead use the one they already have.

- Considerations

This means that this probably cant be pulled from a CDN without first pulling CableReady, but who is even using this with a CDN?